### PR TITLE
[SWA-67][FEAT] - Update existing Arbitrum $USDC into $USDC.e

### DIFF
--- a/src/entities/trades/curve/pools/pools.ts
+++ b/src/entities/trades/curve/pools/pools.ts
@@ -35,7 +35,7 @@ export const POOLS_ARBITRUM_ONE: CurvePool[] = [
     address: '0x7f90122BF0700F9E7e1F688fe926940E8839F353',
     abi: CURVE_3POOL_ABI,
     isMeta: false,
-    tokens: [TOKENS_ARBITRUM_ONE.usdc, TOKENS_ARBITRUM_ONE.usdt],
+    tokens: [TOKENS_ARBITRUM_ONE.usdc_e, TOKENS_ARBITRUM_ONE.usdt],
     // underlyingTokens: [TOKENS_ARBITRUM_ONE.usdc, TOKENS_ARBITRUM_ONE.usdt],
   },
   {
@@ -55,6 +55,11 @@ export const POOLS_ARBITRUM_ONE: CurvePool[] = [
     isMeta: false,
     tokens: [TOKENS_ARBITRUM_ONE.wbtc, TOKENS_ARBITRUM_ONE.renbtc],
   },
+  /**
+   * @TODO update eursusd crypto v2 pool with correct data, TBD in SWAP-67
+   * @see https://curve.fi/#/arbitrum/pools/eursusd/deposit
+   * @see https://linear.app/swaprdev/issue/SWA-67/update-usdc-token-in-arbitrum
+   */
   {
     id: 'eursusd',
     name: 'EURs USD',
@@ -63,7 +68,7 @@ export const POOLS_ARBITRUM_ONE: CurvePool[] = [
     isMeta: true,
     tokens: [
       TOKENS_ARBITRUM_ONE.eurs, // EURs
-      TOKENS_ARBITRUM_ONE.usdc, // USDC
+      TOKENS_ARBITRUM_ONE.usdc_e, // USDC
       TOKENS_ARBITRUM_ONE.usdt, // USDT
     ],
   },

--- a/src/entities/trades/curve/tokens/tokens.ts
+++ b/src/entities/trades/curve/tokens/tokens.ts
@@ -51,12 +51,12 @@ export const TOKENS_ARBITRUM_ONE: Record<string, CurveToken> = {
     isLPToken: true,
     type: TokenType.USD,
     poolTokens() {
-      return [TOKENS_ARBITRUM_ONE.usdc, TOKENS_ARBITRUM_ONE.usdt]
+      return [TOKENS_ARBITRUM_ONE.usdc_e, TOKENS_ARBITRUM_ONE.usdt]
     },
   },
-  usdc: {
-    symbol: 'USDC',
-    name: 'USDC',
+  usdc_e: {
+    symbol: 'USDC.e',
+    name: 'Bridged USDC',
     decimals: 6,
     address: '0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8',
     type: TokenType.USD,

--- a/src/entities/trades/uniswap-v2/constants.ts
+++ b/src/entities/trades/uniswap-v2/constants.ts
@@ -61,8 +61,8 @@ export const USDC: Record<number, Token> = {
     ChainId.ARBITRUM_ONE,
     '0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8',
     6,
-    'USDC',
-    'USD//C'
+    'USDC.e',
+    'Bridged USDC'
   ),
   [ChainId.XDAI]: new Token(
     ChainId.XDAI,

--- a/test/curve-trade.test.ts
+++ b/test/curve-trade.test.ts
@@ -111,10 +111,10 @@ describe('CurveTrade', () => {
     )
     const tokenUSDC = new Token(
       ChainId.ARBITRUM_ONE,
-      TOKENS_ARBITRUM_ONE.usdc.address,
-      TOKENS_ARBITRUM_ONE.usdc.decimals,
-      TOKENS_ARBITRUM_ONE.usdc.symbol,
-      TOKENS_ARBITRUM_ONE.usdc.name
+      TOKENS_ARBITRUM_ONE.usdc_e.address,
+      TOKENS_ARBITRUM_ONE.usdc_e.decimals,
+      TOKENS_ARBITRUM_ONE.usdc_e.symbol,
+      TOKENS_ARBITRUM_ONE.usdc_e.name
     )
 
     const tokenUSDT = new Token(


### PR DESCRIPTION
## Fixes: [SWA-67](https://linear.app/swaprdev/issue/SWA-67/update-usdc-token-in-arbitrum)

# Description

* Update existing (bridged) Arbitrum $USDC into $USDC.e as Circle is creating a native version for $USDC in this chain
* More info: https://arbitrumfoundation.medium.com/usdc-to-come-natively-to-arbitrum-f751a30e3d83

