### PR TITLE
[SWA-96][FEAT] - Update existing Optimism $USDC into $USDC.e

### DIFF
--- a/src/entities/trades/uniswap-v2/constants.ts
+++ b/src/entities/trades/uniswap-v2/constants.ts
@@ -82,8 +82,8 @@ export const USDC: Record<number, Token> = {
     ChainId.OPTIMISM_MAINNET,
     '0x7F5c764cBc14f9669B88837ca1490cCa17c31607',
     6,
-    'USDC',
-    'USD Coin'
+    'USDC.e',
+    'Bridged USDC'
   ),
   [ChainId.BSC_MAINNET]: new Token(
     ChainId.BSC_MAINNET,


### PR DESCRIPTION
## Fixes: [SWA-96](https://linear.app/swaprhq/issue/SWA-96/add-support-for-native-dollarusdc-in-optimism)

# Description

* Update existing (bridged) Optimism $USDC into $USDC.e as Circle is creating a native version for $USDC in this chain
* More info: https://www.circle.com/blog/now-available-usdc-on-op-mainnet

