### PR TITLE
[SWA-99][FEAT] - Update 0x protocol API handling after their API migration

### DIFF
--- a/src/entities/trades/0x/0xTrade.ts
+++ b/src/entities/trades/0x/0xTrade.ts
@@ -23,6 +23,7 @@ import { build0xApiUrl, decodeStringToPercent, platformsFromSources } from './ut
 
 // Debuging logger. See documentation to enable logging.
 const debug0X = createDebug('ecoRouter:0x')
+const headers = { '0x-api-key': `${process.env.REACT_APP_ZEROX_PROTOCOL_API_KEY}` }
 
 /**
  * Represents a trade executed against a list of pairs.
@@ -126,7 +127,7 @@ export class ZeroXTrade extends TradeWithSwapTransaction {
         sellToken,
       })
       // slippagePercentage for the 0X API needs to be a value between 0 and 1, others have between 0 and 100
-      const response = await fetch(apiUrlParams)
+      const response = await fetch(apiUrlParams, { headers })
 
       if (!response.ok) throw new Error('response not ok')
       const json = (await response.json()) as ApiResponse
@@ -191,7 +192,7 @@ export class ZeroXTrade extends TradeWithSwapTransaction {
         sellToken,
       })
       // slippagePercentage for the 0X API needs to be a value between 0 and 1, others have between 0 and 100
-      const response = await fetch(apiUrlParams)
+      const response = await fetch(apiUrlParams, { headers })
       if (!response.ok) throw new Error('response not ok')
       const json = (await response.json()) as ApiResponse
 


### PR DESCRIPTION
## Fixes: [SWA-99](https://linear.app/swaprhq/issue/SWA-99/0x-protocol-not-showing-as-router)

# Description

* Update 0x protocol API handling after their API migration

