### PR TITLE
Fix: when exact out quote swaping gets bigInt error

### DIFF
--- a/src/entities/trades/swapr-v3/SwaprV3.ts
+++ b/src/entities/trades/swapr-v3/SwaprV3.ts
@@ -196,7 +196,10 @@ export class SwaprV3Trade extends TradeWithSwapTransaction {
   public async swapTransaction(options: TradeOptions): Promise<UnsignedTransaction> {
     const isNativeIn = Currency.isNative(this.inputAmount.currency)
     const isNativeOut = Currency.isNative(this.outputAmount.currency)
-    invariant(!(isNativeIn && isNativeOut), 'SwaprV3Trade.swapTransaction: the router does not support both native in and out')
+    invariant(
+      !(isNativeIn && isNativeOut),
+      'SwaprV3Trade.swapTransaction: the router does not support both native in and out',
+    )
 
     const recipient = validateAndParseAddress(options.recipient)
     const amountIn = `0x${this.maximumAmountIn().raw.toString(16)}`
@@ -206,7 +209,7 @@ export class SwaprV3Trade extends TradeWithSwapTransaction {
     const routerContract = getRouterContract()
 
     const baseParams = {
-      tokenIn:  isNativeIn ? WXDAI[ChainId.GNOSIS].address : this.inputAmount.currency.address,
+      tokenIn: isNativeIn ? WXDAI[ChainId.GNOSIS].address : this.inputAmount.currency.address,
       tokenOut: isNativeOut ? WXDAI[ChainId.GNOSIS].address : this.outputAmount.currency.address,
       recipient,
       deadline: dayjs().add(30, 'm').unix(),
@@ -230,6 +233,7 @@ export class SwaprV3Trade extends TradeWithSwapTransaction {
 
     const methodName = isTradeExactInput ? 'exactInputSingle' : 'exactOutputSingle'
     const params = isTradeExactInput ? exactInputSingleParams : exactOutputSingleParams
+    console.log('params:', params)
     const populatedTransaction = await routerContract.populateTransaction[methodName](params, { value })
 
     return populatedTransaction

--- a/src/entities/trades/swapr-v3/SwaprV3.ts
+++ b/src/entities/trades/swapr-v3/SwaprV3.ts
@@ -39,6 +39,7 @@ export interface SwaprV3GetQuoteParams {
   maximumSlippage?: Percent
   recipient?: string
 }
+const ALGEBRA_FEE_PARTS_PER_MILLION = JSBI.BigInt(1_000_000)
 
 export class SwaprV3Trade extends TradeWithSwapTransaction {
   public constructor({
@@ -111,8 +112,8 @@ export class SwaprV3Trade extends TradeWithSwapTransaction {
 
     const fee =
       routes?.length > 0 && routes[0].pools.length > 0
-        ? new Percent(routes[0].pools[0].fee.toString(), '1000000')
-        : new Percent('0', '0')
+        ? new Percent(routes[0].pools[0].fee.toString(), ALGEBRA_FEE_PARTS_PER_MILLION)
+        : new Percent('0', '1')
 
     const parsedAmount = parseUnits(amount.toSignificant(), amount.currency.decimals)
 
@@ -201,8 +202,7 @@ export class SwaprV3Trade extends TradeWithSwapTransaction {
     const isTradeExactInput = this.tradeType === TradeType.EXACT_INPUT
 
     // Swapr Algebra Contract fee param is uint24 type
-    const algebraFee = parseFloat(this.fee.multiply(JSBI.BigInt(1_000_000)).toFixed(1))
-
+    const algebraFee = this.fee.multiply(ALGEBRA_FEE_PARTS_PER_MILLION).toSignificant(1)
     const baseParams = {
       tokenIn: isNativeIn ? WXDAI[ChainId.GNOSIS].address : this.inputAmount.currency.address,
       tokenOut: isNativeOut ? WXDAI[ChainId.GNOSIS].address : this.outputAmount.currency.address,

--- a/src/entities/trades/swapr-v3/swapr-v3.spec.ts
+++ b/src/entities/trades/swapr-v3/swapr-v3.spec.ts
@@ -18,7 +18,7 @@ const recipient = NULL_ADDRESS
 
 describe('SwaprV3', () => {
   describe('Quote', () => {
-    test('should return a EXACT INPUT quote on Gnosis for USDC - WXDAI', async () => {
+    test('should return a EXACT INPUT quote for USDC - WXDAI', async () => {
       const currencyAmount = new TokenAmount(tokenUSDC, parseUnits('2.59', 6).toString())
       const trade = await SwaprV3Trade.getQuote({
         amount: currencyAmount,
@@ -34,7 +34,7 @@ describe('SwaprV3', () => {
       expect(trade?.outputAmount.currency.address).toBe(tokenWXDAI.address)
     })
 
-    test('should return a EXACT INPUT quote on Gnosis for WETH - WXDAI', async () => {
+    test('should return a EXACT INPUT quote for WETH - WXDAI', async () => {
       const currencyAmount = new TokenAmount(tokenWETH, parseUnits('1', 18).toString())
       const trade = await SwaprV3Trade.getQuote({
         amount: currencyAmount,
@@ -50,7 +50,7 @@ describe('SwaprV3', () => {
       expect(trade?.outputAmount.currency.address).toBe(tokenWXDAI.address)
     })
 
-    test('should return a EXACT INPUT quote on Gnosis for SWPR - WXDAI', async () => {
+    test('should return a EXACT INPUT quote for SWPR - WXDAI', async () => {
       const currencyAmount = new TokenAmount(tokenWXDAI, parseUnits('1', 18).toString())
       const trade = await SwaprV3Trade.getQuote({
         amount: currencyAmount,
@@ -66,7 +66,7 @@ describe('SwaprV3', () => {
       expect(trade?.outputAmount.currency.address).toBe(tokenSWPR.address)
     })
 
-    test('should return a exact output quote on Gnosis for WXDAI - USDC', async () => {
+    test('should return a exact output quote for WXDAI - USDC', async () => {
       const currencyAmount = new TokenAmount(tokenWXDAI, parseUnits('2', 18).toString())
       const trade = await SwaprV3Trade.getQuote({
         quoteCurrency: tokenUSDC,
@@ -81,41 +81,41 @@ describe('SwaprV3', () => {
       expect(trade?.inputAmount.currency.address).toBe(tokenUSDC.address)
     })
 
-  test('should return a exact input quote for a native token XDAI - USDC', async () => {
-    const currencyAmount = new TokenAmount(tokenUSDC, parseUnits('2', 6).toString())
-    const trade = await SwaprV3Trade.getQuote({
-      quoteCurrency: Currency.getNative(ChainId.GNOSIS),
-      amount: currencyAmount,
-      maximumSlippage,
-      recipient,
-      tradeType: TradeType.EXACT_OUTPUT,
+    test('should return a exact input quote for a native token XDAI - USDC', async () => {
+      const currencyAmount = new TokenAmount(tokenUSDC, parseUnits('2', 6).toString())
+      const trade = await SwaprV3Trade.getQuote({
+        quoteCurrency: Currency.getNative(ChainId.GNOSIS),
+        amount: currencyAmount,
+        maximumSlippage,
+        recipient,
+        tradeType: TradeType.EXACT_OUTPUT,
+      })
+
+      expect(trade).toBeDefined()
+      expect(trade?.chainId).toEqual(ChainId.GNOSIS)
+      expect(trade?.tradeType).toEqual(TradeType.EXACT_OUTPUT)
+      expect(trade?.outputAmount.currency.address).toBe(tokenUSDC.address)
     })
 
-    expect(trade).toBeDefined()
-    expect(trade?.chainId).toEqual(ChainId.GNOSIS)
-    expect(trade?.tradeType).toEqual(TradeType.EXACT_OUTPUT)
-    expect(trade?.outputAmount.currency.address).toBe(tokenUSDC.address)
-  })
+    // test('should return a EXACT INPUT quote on Gnosis for GNO - WETH', async () => {
+    //   const currencyAmount = new TokenAmount(tokenGNO, parseUnits('1', 18).toString())
+    //   const trade = await SwaprV3Trade.getQuote({
+    //     amount: currencyAmount,
+    //     quoteCurrency: tokenWETH,
+    //     maximumSlippage,
+    //     recipient,
+    //     tradeType: TradeType.EXACT_INPUT,
+    //   })
 
-  // test('should return a EXACT INPUT quote on Gnosis for GNO - WETH', async () => {
-  //   const currencyAmount = new TokenAmount(tokenGNO, parseUnits('1', 18).toString())
-  //   const trade = await SwaprV3Trade.getQuote({
-  //     amount: currencyAmount,
-  //     quoteCurrency: tokenWETH,
-  //     maximumSlippage,
-  //     recipient,
-  //     tradeType: TradeType.EXACT_INPUT,
-  //   })
-
-  //   expect(trade).toBeDefined()
-  //   expect(trade?.chainId).toEqual(ChainId.GNOSIS)
-  //   expect(trade?.tradeType).toEqual(TradeType.EXACT_INPUT)
-  //   expect(trade?.outputAmount.currency.address).toBe(tokenWETH.address)
-  // })
+    //   expect(trade).toBeDefined()
+    //   expect(trade?.chainId).toEqual(ChainId.GNOSIS)
+    //   expect(trade?.tradeType).toEqual(TradeType.EXACT_INPUT)
+    //   expect(trade?.outputAmount.currency.address).toBe(tokenWETH.address)
+    // })
   })
 
   describe('Swap', () => {
-    test('should return a swap for Gnosis for USDC - WXDAI', async () => {
+    test('should return a swap EXACT INPUT for USDC - WXDAI', async () => {
       const currencyAmount = new TokenAmount(tokenUSDC, parseUnits('2', 6).toString())
 
       const trade = await SwaprV3Trade.getQuote({
@@ -134,7 +134,30 @@ describe('SwaprV3', () => {
       const swap = await trade?.swapTransaction(swapOptions)
       expect(swap !== undefined)
     })
-    test('should return a swap on gnosis with native token XDAI - USDC', async () => {
+    test('should return a swap EXACT OUTPUT for USDC - WXDAI', async () => {
+      const currencyAmount = new TokenAmount(tokenWXDAI, parseUnits('2', 18).toString())
+      const trade = await SwaprV3Trade.getQuote({
+        quoteCurrency: tokenUSDC,
+        amount: currencyAmount,
+        maximumSlippage,
+        recipient,
+        tradeType: TradeType.EXACT_OUTPUT,
+      })
+
+      expect(trade).toBeDefined()
+      expect(trade?.chainId).toEqual(ChainId.GNOSIS)
+      expect(trade?.tradeType).toEqual(TradeType.EXACT_OUTPUT)
+      expect(trade?.inputAmount.currency.address).toBe(tokenUSDC.address)
+
+      const swapOptions = {
+        recipient: recipient,
+        account: recipient,
+      }
+
+      const swap = await trade?.swapTransaction(swapOptions)
+      expect(swap !== undefined)
+    })
+    test('should return a swap EXACT INPUT for XDAI - USDC', async () => {
       const currencyAmount = new TokenAmount(tokenUSDC, parseUnits('2', 6).toString())
 
       const trade = await SwaprV3Trade.getQuote({


### PR DESCRIPTION
fee param on SwaprV3 needs to be uint24 type so it needed conversion. 
- improve tokens names
  - setToken  (the token you set on swapbox for eg)
  - quoteToken (the token you want a quote for)
- improve test spec
  -  new test case for covering this issue