### PR TITLE
update: update CoW swap to zero fee amount

### DIFF
--- a/src/entities/trades/gnosis-protocol/CoWTrade.ts
+++ b/src/entities/trades/gnosis-protocol/CoWTrade.ts
@@ -7,6 +7,7 @@ import { SigningResult, UnsignedOrder } from '@cowprotocol/cow-sdk/dist/utils/si
 import { Signer } from '@ethersproject/abstract-signer'
 import { parseUnits } from '@ethersproject/units'
 import dayjs from 'dayjs'
+import JSBI from 'jsbi'
 import invariant from 'tiny-invariant'
 
 import { ChainId, ONE, TradeType, ZERO } from '../../../constants'
@@ -199,6 +200,11 @@ export class CoWTrade extends Trade {
         ? CurrencyAmount.nativeCurrency(ZERO, chainId)
         : new TokenAmount(currencyAmountIn.currency as Token, ZERO)
 
+      const sellAmount = JSBI.add(
+        JSBI.BigInt(quoteResponse.quote.sellAmount.toString()),
+        JSBI.BigInt(quoteResponse.quote.feeAmount.toString()),
+      ).toString()
+
       return new CoWTrade({
         chainId,
         maximumSlippage,
@@ -209,7 +215,7 @@ export class CoWTrade extends Trade {
           : new TokenAmount(tokenOut, quoteResponse.quote.buyAmount.toString()),
         fee,
         feeAmount,
-        quote: quoteResponse,
+        quote: { ...quoteResponse, quote: { ...quoteResponse.quote, sellAmount, feeAmount: '0' } },
       })
     } catch (error) {
       console.error('could not fetch Cow trade', error)
@@ -271,6 +277,11 @@ export class CoWTrade extends Trade {
         ? CurrencyAmount.nativeCurrency(ZERO, chainId)
         : new TokenAmount(currencyIn as Token, ZERO)
 
+      const sellAmount = JSBI.add(
+        JSBI.BigInt(quoteResponse.quote.sellAmount.toString()),
+        JSBI.BigInt(quoteResponse.quote.feeAmount.toString()),
+      ).toString()
+
       return new CoWTrade({
         chainId,
         maximumSlippage,
@@ -279,7 +290,7 @@ export class CoWTrade extends Trade {
         outputAmount,
         fee,
         feeAmount,
-        quote: quoteResponse,
+        quote: { ...quoteResponse, quote: { ...quoteResponse.quote, sellAmount, feeAmount: '0' } },
       })
     } catch (error) {
       console.error('could not fetch COW trade', error)


### PR DESCRIPTION
Convert CoW Protocol swap orders to zero-signed fee orders

```
--FROM--
Sell token: A
Sell amount: x
Fee: f
Buy token: B
Buy amount: y

--TO--
Sell token: A
Sell amount: x + f
Fee: 0
Buy token: B
Buy amount: y
```

Related to https://snapshot.org/#/cow.eth/proposal/0xfb81daea9be89f4f1c251d53fd9d1481129b97c6f38caaddc42af7f3ce5a52ec